### PR TITLE
Feature match wildcards

### DIFF
--- a/src/xnatuploader/matcher.py
+++ b/src/xnatuploader/matcher.py
@@ -97,7 +97,8 @@ class Matcher:
         character after the parameter in the pattern, or the end of the recipe.
 
         "*" and "**" are special recipes for matching and ignoring one or more
-        than one intervening directories.
+        than one intervening directories. They are returned as-is without being
+        converted to a regexp.
 
         A list of all the params is returned so that calling code can know what to
         expect from the pattern without having to run it or reparse the recipe.
@@ -114,7 +115,8 @@ class Matcher:
 
         regexp = ""
         params = []
-        # todo: check for wildcard * and ** operators and return something
+        if recipe == "*":  # or recipe == "**":
+            return [], recipe
         for macro in re.finditer(r"{(.*?)}([^{]*)", recipe):
             param, delimiter = macro.group(1, 2)
             if param in params:
@@ -206,12 +208,16 @@ class Matcher:
         values = {}
         while matchpatterns and dirs:
             pattern = matchpatterns[-1]
-            m = pattern.match(dirs[-1])
-            if not m:
-                return None
-            groups = m.groupdict()
-            for k, v in groups.items():
-                values[k] = v
+            if pattern == "*":
+                # * matches anything, once
+                pass
+            else:
+                m = pattern.match(dirs[-1])
+                if not m:
+                    return None
+                groups = m.groupdict()
+                for k, v in groups.items():
+                    values[k] = v
             matchpatterns.pop()
             dirs.pop()
         return values

--- a/src/xnatuploader/matcher.py
+++ b/src/xnatuploader/matcher.py
@@ -202,23 +202,18 @@ class Matcher:
         Returns: None, or dict of { str: str }
         """
         dirs = list(path.parts)
-        matchpatterns = patterns
+        matchpatterns = patterns[:]
         values = {}
         while matchpatterns and dirs:
             pattern = matchpatterns[-1]
-            logger.warning(f"Matching {dirs[-1]} against {pattern}")
             m = pattern.match(dirs[-1])
             if not m:
-                logger.warning("no match")
                 return None
             groups = m.groupdict()
-            logger.warning(f"matched {groups}")
             for k, v in groups.items():
                 values[k] = v
             matchpatterns.pop()
             dirs.pop()
-        logger.warning(f"got to end {matchpatterns} {dirs}")
-        logger.warning(values)
         return values
 
     def map_values(self, values):

--- a/src/xnatuploader/matcher.py
+++ b/src/xnatuploader/matcher.py
@@ -115,7 +115,7 @@ class Matcher:
 
         regexp = ""
         params = []
-        if recipe == "*":  # or recipe == "**":
+        if recipe == "*" or recipe == "**":
             return [], recipe
         for macro in re.finditer(r"{(.*?)}([^{]*)", recipe):
             param, delimiter = macro.group(1, 2)
@@ -209,8 +209,18 @@ class Matcher:
         while matchpatterns and dirs:
             pattern = matchpatterns[-1]
             if pattern == "*":
-                # * matches anything, once
-                pass
+                matchpatterns.pop()
+                dirs.pop()
+            elif pattern == "**":
+                if len(matchpatterns) > 1:
+                    if matchpatterns[-2].match(dirs[-1]):
+                        # if the next level up matches, stop chasing **
+                        matchpatterns.pop()
+                    else:
+                        # otherwise, keep chasing the **
+                        dirs.pop()
+                else:
+                    raise RecipeException("** at start of pattern")
             else:
                 m = pattern.match(dirs[-1])
                 if not m:
@@ -218,8 +228,8 @@ class Matcher:
                 groups = m.groupdict()
                 for k, v in groups.items():
                     values[k] = v
-            matchpatterns.pop()
-            dirs.pop()
+                matchpatterns.pop()
+                dirs.pop()
         return values
 
     def map_values(self, values):

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -1,0 +1,37 @@
+from xnatuploader.matcher import Matcher
+from pathlib import Path
+
+CASES = [
+    {
+        "patterns": ["{Subject}", "{YYYY}{MM}{DD}", "{Filename}"],
+        "paths": [
+            {
+                "path": "JoeBlow/20120301/test.dcm",
+                "values": {
+                    "Subject": "JoeBlow",
+                    "Session": "20120301",
+                    "Dataset": "test.dcm",
+                },
+            }
+        ],
+    }
+]
+
+MAPPINGS = {
+    "Subject": ["Subject"],
+    "Session": ["YYYY", "MM", "DD"],
+    "Dataset": ["Filename"],
+}
+
+
+def filematch_to_dict(fm):
+    return {"Subject": fm.subject, "Session": fm.session, "Dataset": fm.dataset}
+
+
+def test_match():
+    for case in CASES:
+        config = {"paths": {"test": case["patterns"]}, "mappings": MAPPINGS}
+        matcher = Matcher(config)
+        for path in case["paths"]:
+            results = matcher.match(Path(path["path"]))
+            assert filematch_to_dict(results) == path["values"]

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -2,10 +2,7 @@ from xnatuploader.matcher import Matcher
 from pathlib import Path
 import random
 import string
-import logging
 from datetime import datetime, timedelta
-
-logger = logging.getLogger(__name__)
 
 
 CASES = {
@@ -27,6 +24,19 @@ CASES = {
         "paths": [
             {
                 "path": "JoeBlow/ignoreMe/20120301/test.dcm",
+                "values": {
+                    "Subject": "JoeBlow",
+                    "Session": "20120301",
+                    "Dataset": "test.dcm",
+                },
+            }
+        ],
+    },
+    "multi_glob": {
+        "patterns": ["{Subject}", "{YYYY}{MM}{DD}", "**", "{Filename}"],
+        "paths": [
+            {
+                "path": "JoeBlow/20120301/ignoreMe/ignore_Me_too/test.dcm",
                 "values": {
                     "Subject": "JoeBlow",
                     "Session": "20120301",

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -1,8 +1,15 @@
 from xnatuploader.matcher import Matcher
 from pathlib import Path
+import random
+import string
+import logging
+from datetime import datetime, timedelta
 
-CASES = [
-    {
+logger = logging.getLogger(__name__)
+
+
+CASES = {
+    "basic": {
         "patterns": ["{Subject}", "{YYYY}{MM}{DD}", "{Filename}"],
         "paths": [
             {
@@ -14,8 +21,21 @@ CASES = [
                 },
             }
         ],
-    }
-]
+    },
+    "one_glob": {
+        "patterns": ["{Subject}", "*", "{YYYY}{MM}{DD}", "{Filename}"],
+        "paths": [
+            {
+                "path": "JoeBlow/ignoreMe/20120301/test.dcm",
+                "values": {
+                    "Subject": "JoeBlow",
+                    "Session": "20120301",
+                    "Dataset": "test.dcm",
+                },
+            }
+        ],
+    },
+}
 
 MAPPINGS = {
     "Subject": ["Subject"],
@@ -24,14 +44,63 @@ MAPPINGS = {
 }
 
 
+def random_word():
+    n = random.randint(4, 20)
+    return "".join([random.choice(string.ascii_letters) for i in range(n)])
+
+
+def random_date():
+    dt = datetime.now() - timedelta(days=random.randint(1, 10000))
+    return dt.strftime("%Y%m%d")
+
+
+def pattern_to_path(pattern, subject, session, filename):
+    dirs = []
+    for part in pattern:
+        if part == "*":
+            dirs.append(random_word())
+        elif part == "**":
+            dirs.extend([random_word() for i in range(random.randint(1, 10))])
+        elif part == "{Subject}":
+            dirs.append(subject)
+        elif part == "{YYYY}{MM}{DD}":
+            dirs.append(session)
+        elif part == "{Filename}":
+            dirs.append(filename)
+    return "/".join(dirs)
+
+
+def make_random_path(pattern):
+    """
+    Given a pattern, generates a random path which it will match, and
+    the values which should be matched from it, expanding wildcards as
+    necessary.
+    """
+    subject = random_word()
+    session = random_date()
+    filename = random_word() + ".dcm"
+    path = pattern_to_path(pattern, subject, session, filename)
+    return path, {"Subject": subject, "Session": session, "Dataset": filename}
+
+
 def filematch_to_dict(fm):
     return {"Subject": fm.subject, "Session": fm.session, "Dataset": fm.dataset}
 
 
 def test_match():
-    for case in CASES:
+    for label, case in CASES.items():
         config = {"paths": {"test": case["patterns"]}, "mappings": MAPPINGS}
         matcher = Matcher(config)
         for path in case["paths"]:
             results = matcher.match(Path(path["path"]))
             assert filematch_to_dict(results) == path["values"]
+
+
+def test_random():
+    for label, case in CASES.items():
+        config = {"paths": {"test": case["patterns"]}, "mappings": MAPPINGS}
+        matcher = Matcher(config)
+        for i in range(1000):
+            path, expect = make_random_path(case["patterns"])
+            results = matcher.match(Path(path))
+            assert filematch_to_dict(results) == expect


### PR DESCRIPTION
Adds the ability to specify patterns which match one, none or more levels in a directory tree, like

```
    [ "{subject}", "{YYYY}{MM}{DD}", "*", "{filename}" ] 

    [ "{subject}", "{YYYY}{MM}{DD}", "**", "{filename}" ]
```